### PR TITLE
NOREF: Add additional info to patron-hold-request workflow

### DIFF
--- a/workflows/patron_hold_request.md
+++ b/workflows/patron_hold_request.md
@@ -24,18 +24,62 @@ Due to both this approach, and the circumstances under which the LSP was built, 
 
 7. In order to hit the SCSB API, the HoldRequestConsumer makes a request to the PatronService to change the patron id for the barcode
 
-8. Finally, if that request was either a successful EDD request or was unsuccessful, HoldRequestConsumer pushes the result to the HoldRequestResult event stream.
+8. Finally, if that request was either a successful EDD request or was unsuccessful (two conditions where there is nothing more to process downstream), HoldRequestConsumer pushes the result to the HoldRequestResult event stream.
+   - On the SCSB side, when a request is received:
+     - SCSB changes the item's availability status to "Not Available"
+     - SCSB changes the request status initially as "Processing"
+     - If the request is a retrieval (not an EDD) SCSB then hits our recap/hold-requests endpoint (See item 10 below.)
+     - If the request is an EDD:
+       - If the item belongs to NYPL, SCSB will hit our checkout-requests endpoint to check the item out to a ["Generic EDD Patron"](https://docs.google.com/spreadsheets/d/1mr-LEQc1CZbQPEiLXuKK2UNG15tcRMuezDJofIVwH-4/edit#gid=0). We [translate the generic patron barcode](https://github.com/NYPL/checkout-request-service/blob/d181b6de2190aa5e7e57a47ceff49de0f1123326/src/Controller/CheckoutRequestController.php#L315-L333) into one of a number of different patron barcodes, randomly, to avoid hitting checkout limits on the generic cards.
+       - If the item belongs to a partner, SCSB does not hit any of our hold or checkout-requests endpoints.
 
 9. The HoldRequestResultConsumer picks up that event and emails the patron to let them know the status of their request. If a successful EDD request, it will also update the status of the request in the HoldRequestService to ‘processed’.
 
-10. Moving to the bottom left, if the hold was on a physical item (i.e., not an EDD request) we now want to make sure that it is represented in Sierra, so that a user can see their holds. SCSB initiates this process by hitting our RecapHoldRequestService, through the API Gateway again. It actually does this before it has checked if the item is available in LAS, presumably as it wants to make sure Sierra will allow the hold [which causes us some problems]. This request has the patron barcode, not id. Like the HoldRequestService, RecapHoldRequestService stores the data of the hold in its local DB, and registers an event, in this case within the RecapHoldRequest event stream.
+10. Moving to the bottom left, if the hold was a "retrieval" (i.e. physical delivery, not an EDD request) we now want to make sure that it is represented in Sierra, so that a user can see their holds. SCSB initiates this process by hitting our RecapHoldRequestService, through the API Gateway again. It actually does this before it has checked if the item is available in LAS, presumably as it wants to make sure Sierra will allow the hold [which causes us some problems]. This request has the patron barcode, not id. Like the HoldRequestService, RecapHoldRequestService stores the data of the hold in its local DB, and registers an event, in this case within the RecapHoldRequest event stream. If the RecapHoldRequest call indicates a failure, SCSB marks the request status as "ILS Exception" and rollbacks the item availability status.
 
 11. That event is picked up by the RecapHoldRequestConsumer.
 
 12. The RecapHoldRequestConsumer will query the HoldRequestService to get information about the hold, in particular the patron id.
 
-13. If the item on which the hold was placed is an NYPL item we can just generate a hold through the Sierra REST APIs. If however it was placed on a partner item, we will not have that item stored in Sierra, and so cannot use those APIs; in this case we have to use the NCIP interface, which will generate a dummy record and place a hold on that.
+13. If the item on which the hold was placed is an NYPL item we can just generate a hold through the Sierra REST APIs. If however it was placed on a partner item, we will not have that item stored in Sierra, and so cannot use those APIs; in this case we have to [create an "on-the-fly"](https://github.com/NYPL/recap-hold-request-consumer/blob/6c02f95d2561fce6e6268c8a640f941f637948db/models/sierra_request.rb#L136-L141) (OTF) record (or "virtual record") using the Sierra API, and create a new patron hold on that.
 
 14. Finally RecapHoldRequestConsumer will write an event to the HoldRequestResult, which will be picked up by the HoldRequestResultConsumer. This in turn will email the patron to let them know the hold has been placed, and also to update the request status to ‘processed’ in the HoldRequestService — also updating the JobService — as happened before for successful EDD requests.
 
-15. In the meantime, SCSB polls the JobService to find out when Sierra has successfully placed the Hold. Once that happens it will attempt to place the hold on the item in LAS. If that fails, it will make an HTTP request to RecapHoldRequestService with a Cancel Hold request. The cancel process is described elsewhere.
+15. In the meantime, SCSB polls the JobService to find out when Sierra has successfully placed the Hold. Once that happens it will change the request status to "Pending" and queue up a job to request the item from LAS.
+    - If that LAS request is successful:
+      - If it's a partner item, SCSB will place a checkout call on the owning institution. (The apparent success/failure of the checkout call has no effect on the process.)
+      - If it's an NYPL item, the request status will change to "Retrieval order placed" (this is how it appears in SCSB UI anyway) and delivery will commence. On arrival, staff should find that the item has a hold (created in step 13) identifying the patron.
+
+    - If that LAS request is not successful, SCSB will mark the request as "Exception" and roll back the hold by calling our Cancel Hold Request endpoint (The cancel process is described elsewhere.)
+
+## Troubleshooting
+
+All of the following use the [NYPL Data API Client](https://github.com/NYPL-discovery/node-nypl-data-api-client/).
+
+To place a manual hold request, emulating the kind of call that the Research Catalog front-end does:
+
+```
+node bin/nypl-data-api.js post hold-requests '{ "patron": "PATRONID", "nyplSource": "sierra-nypl", "record": "11690119", "requestType": "hold", "recordType": "i", "pickupLocation": "mal", "neededBy": "2025-01-07T02:32:51Z", "numberOfCopies": "1" }'
+```
+
+To look up a hold request when you know the id:
+
+```
+node bin/nypl-data-api.js get hold-requests/id
+```
+
+To look up a hold request by patron id:
+
+```
+node bin/nypl-data-api.js get hold-requests?patron=PATRONID
+```
+
+(To get a patron id if you only know the patron barcode, use `node bin/nypl-data-api.js get patrons?barcode=BARCODE`.)
+
+To look up a hold request by item id:
+
+```
+node bin/nypl-data-api.js get hold-requests?record=RECORDNUM
+```
+
+(To get an item id if you only know the item barcode, use `node bin/nypl-data-api.js get items?barcode=BARCODE`.)


### PR DESCRIPTION
Adds additional information to patron-hold-request workflow:
 - adds additional detail about what happens on the SCSB side during the hold request process
 - updates how we create OTF records
 - adds sample calls for troubleshooting hold-request issues